### PR TITLE
Fix: exclude field with null value.

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -88,11 +88,13 @@ abstract class Factory
 
     protected function whenNotNull($condition, $value, $default = null): mixed
     {
+        $default = func_num_args() === 3 ? $default : new FactoryMissingValue;
         return $this->when($condition !== null, $value, $default);
     }
 
     protected function executed($condition, $value, $default = null): mixed
     {
+        $default = func_num_args() === 3 ? $default : new FactoryMissingValue;
         return $this->when($condition !== null, $value, $default);
     }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -39,3 +39,9 @@ test('makeSeveral works', function () {
     expect($result)->toHaveCount($count);
     $result->each(fn ($x) => expect($x->fields['id'])->toEqual($id));
 });
+
+test('whenNotNull excludes null field', function () {
+    $result = TestArrayFactory::new()->make();
+
+    expect($result)->not->toHaveKey('id');
+});


### PR DESCRIPTION
Исправление: если в whenNotNull не передавалось значение по умолчанию, то поле не исключалось, а заполнялось null.